### PR TITLE
Fixed defaults and hash id

### DIFF
--- a/src/main/java/se/swedenconnect/opensaml/xmlsec/config/ExtendedDefaultSecurityConfigurationBootstrap.java
+++ b/src/main/java/se/swedenconnect/opensaml/xmlsec/config/ExtendedDefaultSecurityConfigurationBootstrap.java
@@ -28,6 +28,7 @@ import org.opensaml.xmlsec.encryption.support.ChainingEncryptedKeyResolver;
 import org.opensaml.xmlsec.encryption.support.EncryptedKeyResolver;
 import org.opensaml.xmlsec.encryption.support.EncryptionConstants;
 import org.opensaml.xmlsec.encryption.support.InlineEncryptedKeyResolver;
+import org.opensaml.xmlsec.encryption.support.RSAOAEPParameters;
 import org.opensaml.xmlsec.encryption.support.SimpleKeyInfoReferenceEncryptedKeyResolver;
 import org.opensaml.xmlsec.encryption.support.SimpleRetrievalMethodEncryptedKeyResolver;
 import org.opensaml.xmlsec.keyinfo.NamedKeyInfoGeneratorManager;
@@ -95,26 +96,42 @@ public class ExtendedDefaultSecurityConfigurationBootstrap extends DefaultSecuri
     extendedConfig.setWhitelistMerge(config.isWhitelistMerge());
 
     // We want to upgrade the default data encryption algorithms to AEAD crypto.
+    //
+    // TODO: We will move this to a specific bootstrap class for SAML2Int.
+    //
     extendedConfig.setDataEncryptionAlgorithms(Arrays.asList(
-      EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES128_GCM,
+      EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES256_GCM,
       EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES192_GCM,
-      EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES256_GCM
-    ));
+      EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES128_GCM,
+      EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES256,
+      EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES192,
+      EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES128,
+      EncryptionConstants.ALGO_ID_BLOCKCIPHER_TRIPLEDES));
 
     extendedConfig.setDataEncryptionCredentials(config.getDataEncryptionCredentials());
     extendedConfig.setDataKeyInfoGeneratorManager(config.getDataKeyInfoGeneratorManager());
     extendedConfig.setKeyTransportAlgorithmPredicate(config.getKeyTransportAlgorithmPredicate());
     extendedConfig.setKeyTransportEncryptionCredentials(config.getKeyTransportEncryptionCredentials());
+
     // In accordance to new saml2int the default digest algorithm for RSA-OAEP should be SHA-256
-    config.getRSAOAEPParameters().setDigestMethod(EncryptionConstants.ALGO_ID_DIGEST_SHA256);
-    extendedConfig.setRSAOAEPParameters(config.getRSAOAEPParameters());
+    //
+    // TODO: We will move this to a specific bootstrap class for SAML2Int.
+    //
+    RSAOAEPParameters rsaOaepPars = config.getRSAOAEPParameters() != null
+        ? new RSAOAEPParameters(EncryptionConstants.ALGO_ID_DIGEST_SHA256,
+          config.getRSAOAEPParameters().getMaskGenerationFunction(),
+          config.getRSAOAEPParameters().getOAEPParams())
+        : new RSAOAEPParameters(EncryptionConstants.ALGO_ID_DIGEST_SHA256,
+          EncryptionConstants.ALGO_ID_MGF1_SHA1,
+          null);
+    extendedConfig.setRSAOAEPParameters(rsaOaepPars);
     extendedConfig.setRSAOAEPParametersMerge(config.isRSAOAEPParametersMerge());
 
     extendedConfig.setKeyTransportKeyInfoGeneratorManager(config.getKeyTransportKeyInfoGeneratorManager());
 
-    // The order for key wrapping algorithms does not matter for DefaultSecurityConfigurationBootstrap, but it does so
-    // for us,
-    // so we set this property ourselves.
+    // The order for key wrapping algorithms does not matter for DefaultSecurityConfigurationBootstrap,
+    // but it does so for us, so we set this property ourselves.
+    //
     if (config.getKeyTransportEncryptionAlgorithms()
       .equals(DefaultSecurityConfigurationBootstrap.buildDefaultEncryptionConfiguration().getKeyTransportEncryptionAlgorithms())) {
 

--- a/src/main/java/se/swedenconnect/opensaml/xmlsec/encryption/support/ConcatKDFParameters.java
+++ b/src/main/java/se/swedenconnect/opensaml/xmlsec/encryption/support/ConcatKDFParameters.java
@@ -31,7 +31,7 @@ import se.swedenconnect.opensaml.xmlsec.encryption.ConcatKDFParams;
 public class ConcatKDFParameters {
 
   /** Default value for the mandatory attribute AlgorithmID. */
-  public static final byte[] DEFAULT_ALGORITHM_ID = new byte[] { 0x00};
+  public static final byte[] DEFAULT_ALGORITHM_ID = new byte[] { 0x00 };
 
   /** Default value for mandatory attribute PartyUInfo. */
   public static final byte[] DEFAULT_PARTY_UINFO = new byte[] { 0x00 };

--- a/src/main/java/se/swedenconnect/opensaml/xmlsec/encryption/support/ECDHSupport.java
+++ b/src/main/java/se/swedenconnect/opensaml/xmlsec/encryption/support/ECDHSupport.java
@@ -36,7 +36,6 @@ import javax.crypto.KeyAgreement;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 
-import org.apache.xml.security.algorithms.MessageDigestAlgorithm;
 import org.bouncycastle.asn1.ASN1EncodableVector;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.ASN1StreamParser;
@@ -261,11 +260,8 @@ public class ECDHSupport {
           .findFirst()
           .orElse(null);
         if (ecKeyValue != null) {
-          final byte[] ecKeyBytes = Base64Support.decode(ecKeyValue.getPublicKey().getValue());
-
-          // Fix
-
-          encodedPublicKey = getPublicKeyBytes(ecKeyBytes, ecKeyValue.getNamedCurve().getURI());
+          encodedPublicKey = getPublicKeyBytes(
+            Base64Support.decode(ecKeyValue.getPublicKey().getValue()), ecKeyValue.getNamedCurve().getURI());
         }
       }
       else if (!originatorKeyInfo.getDEREncodedKeyValues().isEmpty()) {
@@ -359,7 +355,7 @@ public class ECDHSupport {
       // Black-list checking should already have been done ...
       digest = new SHA1Digest();
     }
-    else if (concatKDFParams.getDigestMethod().getAlgorithm().equals(MessageDigestAlgorithm.ALGO_ID_DIGEST_SHA384)) {
+    else if (concatKDFParams.getDigestMethod().getAlgorithm().equals(SignatureConstants.ALGO_ID_DIGEST_SHA384)) {
       digest = new SHA384Digest();
     }
     else if (concatKDFParams.getDigestMethod().getAlgorithm().equals(EncryptionConstants.ALGO_ID_DIGEST_RIPEMD160)) {


### PR DESCRIPTION
Fixed wrong identifier for SHA 384

ConcatKDF default params are set to 00 instead of 0000, indicating empty parameters with 0 padding bits. We have no reason to ship a default 1 byte parameter of value "00".

Data encryption algorithm set only use AEAD algorithms
