### PR TITLE
Feature/digg 94 saml2int updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <groupId>se.swedenconnect.opensaml</groupId>
   <artifactId>opensaml-security-ext</artifactId>
   <packaging>jar</packaging>
-  <version>1.0.4</version>
+  <version>1.0.5-SNAPSHOT</version>
   
   <name>Sweden Connect :: OpenSAML Security Extensions</name>
   <description>Security and crypto extension library for OpenSAML 3.X</description>

--- a/src/main/java/se/swedenconnect/opensaml/xmlsec/config/SAML2IntSecurityConfiguration.java
+++ b/src/main/java/se/swedenconnect/opensaml/xmlsec/config/SAML2IntSecurityConfiguration.java
@@ -69,7 +69,7 @@ public class SAML2IntSecurityConfiguration extends AbstractSecurityConfiguration
       EncryptionConstants.ALGO_ID_KEYWRAP_TRIPLEDES));
 
     config.setRSAOAEPParameters(new RSAOAEPParameters(
-      SignatureConstants.ALGO_ID_DIGEST_SHA256,
+      SignatureConstants.ALGO_ID_DIGEST_SHA1,
       EncryptionConstants.ALGO_ID_MGF1_SHA1,
       null));
 

--- a/src/test/java/se/swedenconnect/opensaml/xmlsec/config/SAML2IntSecurityConfigurationTest.java
+++ b/src/test/java/se/swedenconnect/opensaml/xmlsec/config/SAML2IntSecurityConfigurationTest.java
@@ -44,7 +44,7 @@ public class SAML2IntSecurityConfigurationTest {
     
     // Assert we have the SAML2Int defaults.
     Assert.assertEquals(EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES256_GCM, config.getDataEncryptionAlgorithms().get(0));
-    Assert.assertEquals(SignatureConstants.ALGO_ID_DIGEST_SHA256, config.getRSAOAEPParameters().getDigestMethod());
+    Assert.assertEquals(SignatureConstants.ALGO_ID_DIGEST_SHA1, config.getRSAOAEPParameters().getDigestMethod());
     Assert.assertTrue(config.getKeyTransportEncryptionAlgorithms().contains(EncryptionConstants.ALGO_ID_KEYTRANSPORT_RSAOAEP11));
     
     // Assert that the extensions of this lib are there ...


### PR DESCRIPTION
SHA-1 is now used for key transport digest (after change in SAML2Int).
