### PR TITLE
ConcatKdf fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <groupId>se.swedenconnect.opensaml</groupId>
   <artifactId>opensaml-security-ext</artifactId>
   <packaging>jar</packaging>
-  <version>1.0.7</version>
+  <version>1.0.8-SNAPSHOT</version>
   
   <name>Sweden Connect :: OpenSAML Security Extensions</name>
   <description>Security and crypto extension library for OpenSAML 3.X</description>

--- a/src/main/java/se/swedenconnect/opensaml/xmlsec/config/ExtendedDefaultSecurityConfigurationBootstrap.java
+++ b/src/main/java/se/swedenconnect/opensaml/xmlsec/config/ExtendedDefaultSecurityConfigurationBootstrap.java
@@ -89,7 +89,8 @@ public class ExtendedDefaultSecurityConfigurationBootstrap extends DefaultSecuri
     extendedConfig.setAgreementMethodAlgorithms(Arrays.asList(EcEncryptionConstants.ALGO_ID_KEYAGREEMENT_ECDH_ES));
     extendedConfig.setKeyDerivationAlgorithms(Arrays.asList(EcEncryptionConstants.ALGO_ID_KEYDERIVATION_CONCAT));
 
-    extendedConfig.setConcatKDFParameters(new ConcatKDFParameters(EncryptionConstants.ALGO_ID_DIGEST_SHA256));
+    extendedConfig.setConcatKDFParameters(new ConcatKDFParameters(
+      EncryptionConstants.ALGO_ID_DIGEST_SHA256, new byte[]{0x00}, new byte[]{0x00}, new byte[]{0x00}));
 
     extendedConfig.setBlacklistedAlgorithms(config.getBlacklistedAlgorithms());
     extendedConfig.setBlacklistMerge(config.isBlacklistMerge());


### PR DESCRIPTION
This fixes inconsistency between this implementation and OpenSAML 4 that do require ConcatKDF parameters to have a value.